### PR TITLE
fix(transaction): change result_meta_xdr to be a optional

### DIFF
--- a/src/resources/transaction.rs
+++ b/src/resources/transaction.rs
@@ -49,7 +49,7 @@ pub struct Transaction {
     /// A base64 encoded string of the raw `TransactionResult` XDR struct for this transaction.
     pub result_xdr: String,
     /// A base64 encoded string of the raw `TransactionMeta` XDR struct for this transaction.
-    pub result_meta_xdr: String,
+    pub result_meta_xdr: Option<String>,
     /// A base64 encoded string of the raw `LedgerEntryChanges` XDR struct produced by taking fees for this transaction.
     pub fee_meta_xdr: String,
     /// The type of memo. Potential values include `MEMO_TEXT`, `MEMO_ID`, `MEMO_HASH`, `MEMO_RETURN`.


### PR DESCRIPTION
-Transaction meta result_meta_xdr will be removed from the SDF hosted Horizon API (horizon.stellar.org) in Q3 2024